### PR TITLE
Added the ability to set ReadAttributes & WriteAttributes for User Pool Client Settings and Added every AllowedOAuthScopes in CloudFormation YAML template file

### DIFF
--- a/CloudFormationCognitoUserPoolClientSettings.js
+++ b/CloudFormationCognitoUserPoolClientSettings.js
@@ -15,7 +15,9 @@ exports.handler = async (event) => {
                     LogoutURLs: [event.ResourceProperties.LogoutURL],
                     AllowedOAuthFlowsUserPoolClient: (event.ResourceProperties.AllowedOAuthFlowsUserPoolClient == 'true'),
                     AllowedOAuthFlows: event.ResourceProperties.AllowedOAuthFlows,
-                    AllowedOAuthScopes: event.ResourceProperties.AllowedOAuthScopes
+                    AllowedOAuthScopes: event.ResourceProperties.AllowedOAuthScopes,
+					ReadAttributes: event.ResourceProperties.ReadAttributes,
+					WriteAttributes: event.ResourceProperties.WriteAttributes
                 }).promise();
                 
                 await sendCloudFormationResponse(event, 'SUCCESS');

--- a/SampleInfrastructure.template.yaml
+++ b/SampleInfrastructure.template.yaml
@@ -110,7 +110,49 @@ Resources:
       AllowedOAuthFlows:
         - code
       AllowedOAuthScopes:
-        - openid
+        - phone
+				- email
+				- openid
+				- aws.cognito.signin.user.admin
+				- profile
+      ReadAttributes:
+        - address
+			  - birthdate
+				- email
+				- email_verified
+				- family_name
+				- gender
+				- given_name
+				- locale
+				- middle_name
+				- name
+				- nickname
+				- phone_number
+				- phone_number_verified
+				- picture
+				- preferred_username
+				- profile
+				- updated_at
+				- website
+				- zoneinfo
+      WriteAttributes:
+        - address
+				- birthdate
+				- email
+				- family_name
+				- gender
+				- given_name
+				- locale
+				- middle_name
+				- name
+				- nickname
+				- phone_number
+				- picture
+				- preferred_username
+				- profile
+				- updated_at
+				- website
+				- zoneinfo
   UserPoolTestDomain:
     Type: 'Custom::CognitoUserPoolDomain'
     Properties:


### PR DESCRIPTION
Hi!

First of all, thank you so much for this code! You really saved me the effort of doing it myself :)

I have added the ability to set ReadAttributes & WriteAttributes for the User Pool Client's Settings because, if you create a User Pool Client with these on and after that you set its Settings using your code, those get cleared. In:

https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_UpdateUserPoolClient.html

It mentions:

"If you don't provide a value for an attribute, it will be set to the default value."

The docs do not specify the defaults for ReadAttributes & WriteAttributes but apparently those defaults are NULL.


I also added every possible AllowedOAuthScopes in CloudFormation YAML template file since the docs (see previous link) mention the following supported values:

"phone", "email", "openid", and "Cognito"

But, in reality the supported values are the ones in this pull request.

"Cognito" is really "aws.cognito.signin.user.admin" and this made my template to fail over and over again.

Not really a problem with your code, but I figured if someone came across it and wanted (as I did) to set "aws.cognito.signin.user.admin", seeing it in the YAML will aid them in getting the proper value and not waste 2 hs. of their lives (as I did). I also reported the fault in the docs to AWS.